### PR TITLE
whitespaces fix & portIntPinConfig fix & getIntF created

### DIFF
--- a/Centipede.cpp
+++ b/Centipede.cpp
@@ -197,10 +197,10 @@ int Centipede::portCaptureRead(int port) {
 
 void Centipede::portIntPinConfig(int port, int drain, int polarity) {
 
-  WriteRegisterPin(port, 1, 0x0A, drain);
-  WriteRegisterPin(port, 1, 0x0B, drain);
-  WriteRegisterPin(port, 0, 0x0A, polarity);
-  WriteRegisterPin(port, 0, 0x0B, polarity);
+  WriteRegisterPin(port, 2, 0x0A, drain);
+  WriteRegisterPin(port, 2, 0x0B, drain);
+  WriteRegisterPin(port, 1, 0x0A, polarity);
+  WriteRegisterPin(port, 1, 0x0B, polarity);
 
 }
 
@@ -224,6 +224,15 @@ int Centipede::portRead(int port) {
 
 }
 
+// JFM: Return port interrupt flags (1=pin interrupted)
+uint16_t Centipede::getIntF(int port) {
 
+  ReadRegisters(port, 0x0e, 2);
+
+  int receivedval = CSDataArray[0];
+  receivedval |= CSDataArray[1] << 8;
+
+  return receivedval;
+}
 
 

--- a/Centipede.cpp
+++ b/Centipede.cpp
@@ -47,12 +47,12 @@ void Centipede::WriteRegisters(int port, int startregister, int quantity) {
 #if defined(ARDUINO) && ARDUINO >= 100
     Wire.write((byte)startregister);
     for (int i = 0; i < quantity; i++) {
-		Wire.write((byte)CSDataArray[i]);
+        Wire.write((byte)CSDataArray[i]);
     }
 #else
     Wire.send((byte)startregister);
     for (int i = 0; i < quantity; i++) {
-		Wire.send((byte)CSDataArray[i]);
+        Wire.send((byte)CSDataArray[i]);
     }
 #endif
 
@@ -64,19 +64,19 @@ void Centipede::ReadRegisters(int port, int startregister, int quantity) {
 
   Wire.beginTransmission(CSAddress + port);
 #if defined(ARDUINO) && ARDUINO >= 100
-	Wire.write((byte)startregister);
-	Wire.endTransmission();
-	Wire.requestFrom(CSAddress + port, quantity);
-	for (int i = 0; i < quantity; i++) {
-		CSDataArray[i] = Wire.read();
-	}
+    Wire.write((byte)startregister);
+    Wire.endTransmission();
+    Wire.requestFrom(CSAddress + port, quantity);
+    for (int i = 0; i < quantity; i++) {
+        CSDataArray[i] = Wire.read();
+    }
 #else
-	Wire.send((byte)startregister);
-	Wire.endTransmission();
-	Wire.requestFrom(CSAddress + port, quantity);
-	for (int i = 0; i < quantity; i++) {
-		CSDataArray[i] = Wire.receive();
-	}
+    Wire.send((byte)startregister);
+    Wire.endTransmission();
+    Wire.requestFrom(CSAddress + port, quantity);
+    for (int i = 0; i < quantity; i++) {
+        CSDataArray[i] = Wire.receive();
+    }
 #endif
 
 }
@@ -84,51 +84,51 @@ void Centipede::ReadRegisters(int port, int startregister, int quantity) {
 
 void Centipede::WriteRegisterPin(int port, int regpin, int subregister, int level) {
 
-  ReadRegisters(port, subregister, 1); 
-  
+  ReadRegisters(port, subregister, 1);
+
   if (level == 0) {
     CSDataArray[0] &= ~(1 << regpin);
   }
   else {
     CSDataArray[0] |= (1 << regpin);
   }
-  
+
   WriteRegisters(port, subregister, 1);
-  
+
 }
 
 void Centipede::pinMode(int pin, int mode) {
-  
+
   int port = pin >> 4;
   int subregister = (pin & 8) >> 3;
 
   int regpin = pin - ((port << 1) + subregister)*8;
 
   WriteRegisterPin(port, regpin, subregister, mode ^ 1);
-  
+
 }
 
 void Centipede::pinPullup(int pin, int mode) {
-  
+
   int port = pin >> 4;
   int subregister = (pin & 8) >> 3;
 
   int regpin = pin - ((port << 1) + subregister)*8;
 
   WriteRegisterPin(port, regpin, 0x0C + subregister, mode);
-  
+
 }
 
 
 void Centipede::digitalWrite(int pin, int level) {
-  
+
   int port = pin >> 4;
   int subregister = (pin & 8) >> 3;
 
   int regpin = pin - ((port << 1) + subregister)*8;
 
   WriteRegisterPin(port, regpin, 0x12 + subregister, level);
-  
+
 }
 
 int Centipede::digitalRead(int pin) {
@@ -145,21 +145,21 @@ int Centipede::digitalRead(int pin) {
 }
 
 void Centipede::portMode(int port, int value) {
-  
+
   CSDataArray[0] = value;
   CSDataArray[1] = value>>8;
-  
+
   WriteRegisters(port, 0x00, 2);
-  
+
 }
 
 void Centipede::portWrite(int port, int value) {
-  
+
   CSDataArray[0] = value;
   CSDataArray[1] = value>>8;
-  
+
   WriteRegisters(port, 0x12, 2);
-  
+
 }
 
 void Centipede::portInterrupts(int port, int gpintval, int defval, int intconval) {
@@ -169,17 +169,17 @@ void Centipede::portInterrupts(int port, int gpintval, int defval, int intconval
 
   CSDataArray[0] = gpintval;
   CSDataArray[1] = gpintval>>8;
-  
+
   WriteRegisters(port, 0x04, 2);
 
   CSDataArray[0] = defval;
   CSDataArray[1] = defval>>8;
-  
+
   WriteRegisters(port, 0x06, 2);
 
   CSDataArray[0] = intconval;
   CSDataArray[1] = intconval>>8;
-  
+
   WriteRegisters(port, 0x08, 2);
 
 }
@@ -191,7 +191,7 @@ int Centipede::portCaptureRead(int port) {
   int receivedval = CSDataArray[0];
   receivedval |= CSDataArray[1] << 8;
 
-  return receivedval;  
+  return receivedval;
 
 }
 
@@ -205,12 +205,12 @@ void Centipede::portIntPinConfig(int port, int drain, int polarity) {
 }
 
 void Centipede::portPullup(int port, int value) {
-  
+
   CSDataArray[0] = value;
   CSDataArray[1] = value>>8;
-  
+
   WriteRegisters(port, 0x0C, 2);
-  
+
 }
 
 int Centipede::portRead(int port) {
@@ -220,7 +220,7 @@ int Centipede::portRead(int port) {
   int receivedval = CSDataArray[0];
   receivedval |= CSDataArray[1] << 8;
 
-  return receivedval;  
+  return receivedval;
 
 }
 

--- a/Centipede.cpp
+++ b/Centipede.cpp
@@ -47,12 +47,12 @@ void Centipede::WriteRegisters(int port, int startregister, int quantity) {
 #if defined(ARDUINO) && ARDUINO >= 100
     Wire.write((byte)startregister);
     for (int i = 0; i < quantity; i++) {
-        Wire.write((byte)CSDataArray[i]);
+      Wire.write((byte)CSDataArray[i]);
     }
 #else
     Wire.send((byte)startregister);
     for (int i = 0; i < quantity; i++) {
-        Wire.send((byte)CSDataArray[i]);
+      Wire.send((byte)CSDataArray[i]);
     }
 #endif
 
@@ -68,14 +68,14 @@ void Centipede::ReadRegisters(int port, int startregister, int quantity) {
     Wire.endTransmission();
     Wire.requestFrom(CSAddress + port, quantity);
     for (int i = 0; i < quantity; i++) {
-        CSDataArray[i] = Wire.read();
+      CSDataArray[i] = Wire.read();
     }
 #else
     Wire.send((byte)startregister);
     Wire.endTransmission();
     Wire.requestFrom(CSAddress + port, quantity);
     for (int i = 0; i < quantity; i++) {
-        CSDataArray[i] = Wire.receive();
+      CSDataArray[i] = Wire.receive();
     }
 #endif
 

--- a/Centipede.h
+++ b/Centipede.h
@@ -14,24 +14,24 @@ extern uint8_t CSDataArray[2];
 
 class Centipede
 {
-	public:
-      		Centipede();
-		void pinMode(int pin, int mode);
-		void pinPullup(int pin, int mode);
-		void digitalWrite(int pin, int level);
-		int digitalRead(int pin);
-		void portMode(int port, int value);
-		void portPullup(int port, int value);
-		void portWrite(int port, int value);
-		int portRead(int port);
-	        void portInterrupts(int port, int gpintval, int defval, int intconval);
-	       int portCaptureRead(int port);
-		void portIntPinConfig(int port, int drain, int polarity);
-		void initialize();
-	//private:
-		void WriteRegisters(int port, int startregister, int quantity);
-		void ReadRegisters(int port, int startregister, int quantity);
-		void WriteRegisterPin(int port, int regpin, int subregister, int level);
+  public:
+    Centipede();
+    void pinMode(int pin, int mode);
+    void pinPullup(int pin, int mode);
+    void digitalWrite(int pin, int level);
+    int digitalRead(int pin);
+    void portMode(int port, int value);
+    void portPullup(int port, int value);
+    void portWrite(int port, int value);
+    int portRead(int port);
+    void portInterrupts(int port, int gpintval, int defval, int intconval);
+    int portCaptureRead(int port);
+    void portIntPinConfig(int port, int drain, int polarity);
+    void initialize();
+  //private:
+    void WriteRegisters(int port, int startregister, int quantity);
+    void ReadRegisters(int port, int startregister, int quantity);
+    void WriteRegisterPin(int port, int regpin, int subregister, int level);
 };
 
 #endif

--- a/Centipede.h
+++ b/Centipede.h
@@ -25,6 +25,7 @@ class Centipede
     void portWrite(int port, int value);
     int portRead(int port);
     void portInterrupts(int port, int gpintval, int defval, int intconval);
+    uint16_t getIntF(int port);
     int portCaptureRead(int port);
     void portIntPinConfig(int port, int drain, int polarity);
     void initialize();


### PR DESCRIPTION
This PR include 3 different topics:

1. The whitespaces has been fixed.
* All the files has been converted from CRLF (dos) to LF (unix)
* The tabs has been removed
* All the indentation is by 2 spaces (i have tried to follow the pre-existing standard of the files)
* The column has been (hopefully) all aligned properly
* git diff -w should show that the code is not dramatically changing as you see it in the github diff

2. Fixed Centipede::portIntPinConfig
* The code has been fixed according to https://www.best-microcontroller-projects.com/mcp23017-interrupt.html

> The following is the register description for IOCON:
> MCP23017 IOCON Control Register Bits
> As identified above bit 0 is an undefined and unused bit. INTPOL should be bit 1, and ODR should be bit 2.

3. Centipede::getIntF
* The code has been fixed according to https://www.best-microcontroller-projects.com/mcp23017-interrupt.html

> The library has not been developed far enough for multiple open drain operation and is missing a member function to detect the state of INTFA and INTFB registers 0x0e and 0x0f. These return an interrupt flag state that allows you to determine which port (device) produced an interrupt (and it could be more than one device).
